### PR TITLE
mpvconfigurator.pro: Remove reference to tempfix.ui.

### DIFF
--- a/src/mpvconfigurator.pro
+++ b/src/mpvconfigurator.pro
@@ -52,8 +52,7 @@ FORMS    += mainwindow.ui \
     tabmisc.ui \
     tabextensions.ui \
     unknownsettingstab.ui \
-    tabconfig.ui \
-    tempfix.ui
+    tabconfig.ui
 
 QMAKE_CXXFLAGS += -std=c++11
 


### PR DESCRIPTION
Fixes compilation, that file's just not used.

Should fix issue #5 . 
