### PR TITLE
gitignore: Add exclusion of "build" next to "src".

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@
 *.exe
 *.out
 *.app
+
+build/*


### PR DESCRIPTION
Allows to build in "build" inside repo checkout without making git unhappy.
