### PR TITLE
travis: Add travis file to regularly test compilations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,44 @@
+language: cpp
+
+sudo: true
+
+compiler:
+  # Clang not yet qith Qt 5.0
+  #- clang
+  - gcc
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+      - ubuntu-sdk-team
+    packages:
+      - g++-5
+      #- qt5-qmake qtbase5-dev qtdeclarative5-dev 
+
+cache:
+  directories:
+    - $HOME/.ccache
+
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq qt5-qmake qtbase5-dev qtdeclarative5-dev
+
+install:
+  # g++-5 on linux
+  - if [ "$CXX" = "g++" ]; then export CC="gcc-5"; export CXX="g++-5"; fi
+
+before_script:
+  - mkdir -p ${TRAVIS_BUILD_DIR}/build
+  - mkdir -p ${TRAVIS_BUILD_DIR}/install
+  - cd ${TRAVIS_BUILD_DIR}/build
+  - echo -e '\nlinux-g++* {\nQMAKE_CXX = '${CXX}'\nQMAKE_CC = '${CC}'\n}\n' >> ../src/mpvconfigurator.pro
+
+script:
+  - env
+  - qmake -qt=qt5 -v
+  - if [ "$CXX" = "clang++" ]; then qmake -qt=qt5 -spec linux-clang ../src; else qmake -qt=qt5 ../src; fi
+  - make
+  #- make install
+  #- cd ${TRAVIS_BUILD_DIR}/install
+


### PR DESCRIPTION
Can not yet run on docker-based-infrastructure since Qt 5 is needed.
Since Qt 5.0 is the only available version for now for Ubuntu 12.04,
clang can not be tested (yet).
As such, we test compilation with g++-5.
Most pieces to move to the new travis-infrastructure (once Qt is whitelisted)
are already in place, though.
